### PR TITLE
Add sre tools

### DIFF
--- a/ansible/files/jira_config.yml
+++ b/ansible/files/jira_config.yml
@@ -1,0 +1,47 @@
+endpoint: https://litmus.atlassian.net
+editor: nvim
+project: OPS
+user: youruser
+login: youremail@litmus.com
+accountId: 1-2-3:1-2-3-4-5-a
+# click on your profile in Jira and the URL will include this value
+
+#password-source: gopass
+#password-name: litmus.atlassian.net/youremail@litmus.com
+
+custom-commands:
+  - name: tf12
+    help: Display open issues for Terraform upgrade
+    script: |-
+      {{jira}} list --template table -l 5 --query 'project = "OPS" AND resolution = Unresolved and statusCategory in ("To Do") AND "Epic Link" = "TF 012 Upgrade" AND assignee is EMPTY ORDER BY rank ASC, created' 
+  - name: list-clones
+    help: Update sub-tasks to remove clone prefix
+    args:
+      - name: parent
+        required: true
+    script: |-
+      {{jira}} list --template json --query 'project = "OPS" AND parent = "{{ args.parent }}" AND summary ~ "CLONE"'
+  - name: zapi
+    help: Create in-progress Zap issue
+    args:
+      - name: summary
+        type: string
+        repeat: true
+        required: true
+    options:
+      - name: accountId
+        default: $JIRA_ACCOUNT_ID
+    script: |-
+      {{jira}} create -p OPS -i Zap -t create-zap -o size=M -o assignee={{options.accountId}} -o summary="{{ range $i,$w := args.summary }}{{ if $i }} {{ end }}{{ $w }}{{ end }}"
+  - name: zapd
+    help: Create completed Zap issue
+    args:
+      - name: summary
+        type: string
+        repeat: true
+        required: true
+    options:
+      - name: accountId
+        default: $JIRA_ACCOUNT_ID
+    script: |-
+      {{jira}} create -p OPS -i Zap -t create-zap --noedit -o size=S -o assignee={{options.accountId}} -o summary="{{ range $i,$w := args.summary }}{{ if $i }} {{ end }}{{ $w }}{{ end }}"

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -48,6 +48,12 @@
           - ansible
           - vagrant
 
+    - name: "Install SRE Packages: pip"
+      pip:
+        name:
+          - pywinrm #used to run Ansible against Windows nodes
+          - redis #used in litmus-admin-ansible
+
     - name: "Fetch AWS CLI v2"
       unarchive:
         remote_src: true

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -24,6 +24,7 @@
           - fdutils
           - fzf
           - git
+          - irpas
           - jq
           - lsof
           - procps
@@ -39,6 +40,12 @@
           - vim
           - wget
           - zsh
+
+    - name: "Install SRE Packages"
+      package:
+        name:
+          - ansible
+          - vagrant
 
     - name: "Fetch AWS CLI v2"
       unarchive:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -10,8 +10,8 @@
 
     - name: "Update/upgrade {{ ansible_distribution_release }} packages"
       apt:
-        update_cache: true
-        upgrade: true
+        update_cache: 'yes'
+        upgrade: 'yes'
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: "Install Base Packages"
@@ -38,6 +38,7 @@
           - unattended-upgrades
           - unzip
           - vim
+          - virtualbox-qt
           - wget
           - zsh
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -10,7 +10,7 @@
 
     - name: "Update/upgrade {{ ansible_distribution_release }} packages"
       apt:
-        update_cache: 'yes'
+        update_cache: yes
         upgrade: 'yes'
       when: ansible_facts['os_family'] == 'Debian'
 
@@ -48,11 +48,35 @@
           - ansible
           - vagrant
 
+    - name: Ensures jira directory exists
+      file:
+        path: "/home/vagrant/.jira.d"
+        state: directory
+
+    - name: Ensures bash profile exists
+      copy:
+        content: ""
+        dest: "/home/vagrant/.bash_profile"
+        force: no
+
+    - name: Add jira-cli to bash profile
+      blockinfile:
+        dest: "/home/vagrant/.bash_profile"
+        content: |
+          #Jira Setup
+          eval "$(jira --completion-script-bash)"
+
+    - name: "Setup Jira cli"
+      copy:
+        src: files/jira_config.yml
+        dest: "/home/vagrant/.jira.d/config.yml"
+
     - name: "Install SRE Packages: pip"
       pip:
         name:
           - pywinrm #used to run Ansible against Windows nodes
           - redis #used in litmus-admin-ansible
+          - jira-cli
 
     - name: "Fetch AWS CLI v2"
       unarchive:

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -46,7 +46,7 @@
         "only":[
           "docker-2004"
         ],
-        "repository": "{{ user `docker_hub_username` }}ctl-ubuntu2004",
+        "repository": "{{ user `docker_hub_username` }}/ctl-ubuntu2004",
         "tags": [
           "latest",
           "{{ user `ver` }}"

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -46,7 +46,7 @@
         "only":[
           "docker-2004"
         ],
-        "repository": "{{ user `docker_hub_username` }}/ctl-ubuntu2004",
+        "repository": "{{ user `docker_hub_username` }}ctl-ubuntu2004",
         "tags": [
           "latest",
           "{{ user `ver` }}"


### PR DESCRIPTION
Error messages for update cache:
```    
docker-2004: TASK [Update/upgrade focal packages] *******************************************
docker-2004: [WARNING]: The value "True" (type bool) was converted to "'True'" (type
```

`virtualbox-qt` and `irpas` (for `timestamp`) is needed to build from this repo.
pip:`Pywinrm` is used to run ansible against Windows hosts. `Redis` is used in litmus-admin-ansible.
It adds the jira cli setup.